### PR TITLE
Update acknowledgements and license information

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,3 @@ For `Makefile`:
 
 #### Pre-push hook that builds documentation
 `01-create_docs.sh` is a shell script that builds documentation using `sphinx` before a `git push` is completed.
-
-## Acknowledgments
-`hook_runner.sh` is derived from the [repository by nkantar](https://github.com/nkantar/Autohook).

--- a/hooks/hook_runner.sh
+++ b/hooks/hook_runner.sh
@@ -2,8 +2,30 @@
 
 # hook_runner.sh is a framework for detecting and executing git hooks. The framework
 # automatically creates symlinks of all scripts in the hooks directory, makes each
-# script an executable, and then executes them. hook_runner.sh is derived from code from
-# the repository by nkantar (https://github.com/nkantar/Autohook). License found below.
+# script an executable, and then executes them. hook_runner.sh is modified from code in
+# the repository by Nikola Kantar (https://github.com/nkantar/Autohook).
+
+# MIT License
+
+# Copyright (c) 2017 Nikola Kantar
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
 install() {
     # Un-comment to select which git actions trigger a hook
@@ -114,24 +136,3 @@ main() {
 
 main "$@"
 
-# MIT License
-
-# Copyright (c) 2017 Nikola Kantar
-
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.


### PR DESCRIPTION
- Acknowledgement section was removed
- License was moved to top of `hook_runner.sh`